### PR TITLE
update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-All files, excluding english.json, are licensed under the MIT license.
+All files, excluding mama_pi_ante_toki.json, are licensed under the MIT license.
 
 Copyright (c) 2021 cominixo
 Copyright (c) 2021-2022 Kylie McClain <kylie@somas.is>


### PR DESCRIPTION
https://github.com/somasis/discord-tokipona/commit/35554c319b47bfe49ee5c81793fe07e8b4db2318 renames english.json -> mama_pi_ante_toki.json however the license still mentioned an "english.json" ever since https://github.com/somasis/discord-tokipona/commit/da482e02f34be1937269ad92debb67d605db9595 and this PR updates that part of the license file to contain the correct filename.